### PR TITLE
Clean up environment module and remove experiment-specific fields

### DIFF
--- a/src/swc/aeon/rigs/environment.py
+++ b/src/swc/aeon/rigs/environment.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from pydantic import Field
 from swc.aeon.rigs.base import BaseSchema, Device
 
@@ -25,6 +26,7 @@ class LightController(BaseSchema):
 class WeightScale(Device):
     """Represents acquisition functionality for automated habitat weighing scales."""
 
+    device_type: Literal["WeightScale"] = "WeightScale"
     port_name: str = Field(examples=["COM"], description="The name of the device serial port.")
     filter_window: int = Field(
         default=40, description="Sliding window size of the weight linear regression filter."

--- a/src/swc/aeon/rigs/environment.py
+++ b/src/swc/aeon/rigs/environment.py
@@ -3,7 +3,7 @@ from pydantic import Field
 from swc.aeon.rigs.base import BaseSchema, Device
 
 
-class LightController(BaseSchema):
+class LightCycle(BaseSchema):
     """Represents a network client for automated room light control."""
 
     event_socket: str = Field(

--- a/src/swc/aeon/rigs/environment.py
+++ b/src/swc/aeon/rigs/environment.py
@@ -31,7 +31,3 @@ class WeightScale(Device):
     filter_window: int = Field(
         default=40, description="Sliding window size of the weight linear regression filter."
     )
-    weight_baseline_refactory_period: float = Field(
-        default=5,
-        description="The time between consecutive weight baseline when subject in center of habitat in seconds.",
-    )


### PR DESCRIPTION
[Add missing device type field for weight scale](https://github.com/SainsburyWellcomeCentre/aeon_swc_rigs/commit/91f6dbcb5aff1c103525dec2ef99190f68b93bad)

Models derived from the `Device` class must define the `device_type` field.

[Remove experiment-specific field from WeightScale](https://github.com/SainsburyWellcomeCentre/aeon_swc_rigs/commit/eb074abe409030f5d23ccaeb1e8951ed415371f3) 

Originally used for computer vision based baselining logic but not part
of the device parameters themselves.

[Rename LightController to LightCycle](https://github.com/SainsburyWellcomeCentre/aeon_swc_rigs/commit/2657f25b7573da6ef2f52b51e175483833c8e9b4) 

This is to match the original grouping in experiment workflows. May be
refactored in the future.